### PR TITLE
Automate pypi builds and uploads on new release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,33 @@
+# This workflow will upload a Python Package using Twine when a new version is released (pre-releases are excluded)
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package incomfort-client
+
+on:
+  release:
+    types: [published]
+    branches:
+      - master
+
+jobs:
+  deploy:
+    if: "!github.event.release.prerelease"
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish incomfort-client
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
## Context

Automates pypi builds and uploads on a new release. This project no longer uses CircleCI services to perform these tasks.