### PR TITLE
Fix typing issues

### DIFF
--- a/incomfortclient/__init__.py
+++ b/incomfortclient/__init__.py
@@ -30,7 +30,7 @@ BITMASK_PUMP = 0x02  # pump state: on / off
 BITMASK_TAP = 0x04  # tap (DHW) state: function on / off
 
 # key label: displ_code
-DISPLAY_CODES: list[int, str] = {
+DISPLAY_CODES: dict[int, str] = {
     0: "opentherm",
     15: "boiler ext.",
     24: "frost",
@@ -46,7 +46,7 @@ DISPLAY_CODES: list[int, str] = {
     240: "boiler int.",
     255: "buffer",
 }
-FAULT_CODES: list[int, str] = {
+FAULT_CODES: dict[int, str] = {
     0: "Sensor fault after self check",
     1: "Temperature too high",
     2: "S1 and S2 interchanged",
@@ -69,7 +69,7 @@ FAULT_CODES: list[int, str] = {
     30: "Gas valve relay faulty",
 }  # "0.0": "Low system pressure"
 
-HEATER_ATTRS: tuple[str] = (
+HEATER_ATTRS: tuple[str, ...] = (
     "display_code",
     "display_text",
     "fault_code",
@@ -82,9 +82,9 @@ HEATER_ATTRS: tuple[str] = (
     "pressure",
     "serial_no",
 )
-HEATER_ATTRS_RAW: tuple[str] = ("nodenr", "rf_message_rssi", "rfstatus_cntr")
+HEATER_ATTRS_RAW: tuple[str, ...] = ("nodenr", "rf_message_rssi", "rfstatus_cntr")
 
-ROOM_ATTRS: tuple[str] = ("room_temp", "setpoint", "override")
+ROOM_ATTRS: tuple[str, ...] = ("room_temp", "setpoint", "override")
 
 OVERRIDE_MAX_TEMP = 30.0
 OVERRIDE_MIN_TEMP = 5.0


### PR DESCRIPTION
```
(.venv) ~/PycharmProjects/incomfort-client git:[ruff]
mypy .
src/incomfortclient/__init__.py:33: error: "list" expects 1 type argument, but 2 given  [type-arg]
src/incomfortclient/__init__.py:33: error: Incompatible types in assignment (expression has type "dict[int, str]", variable has type "list[Any]")  [assignment]
src/incomfortclient/__init__.py:49: error: "list" expects 1 type argument, but 2 given  [type-arg]
src/incomfortclient/__init__.py:49: error: Incompatible types in assignment (expression has type "dict[int, str]", variable has type "list[Any]")  [assignment]
src/incomfortclient/__init__.py:72: error: Incompatible types in assignment (expression has type tuple[str, str, ... <9 more items>], variable has type tuple[str])  [assignment]
src/incomfortclient/__init__.py:85: error: Incompatible types in assignment (expression has type "tuple[str, str, str]", variable has type "tuple[str]")  [assignment]
src/incomfortclient/__init__.py:87: error: Incompatible types in assignment (expression has type "tuple[str, str, str]", variable has type "tuple[str]")  [assignment]
src/incomfortclient/__init__.py:97: error: Missing type parameters for generic type "dict"  [type-arg]
src/incomfortclient/__init__.py:108: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
src/incomfortclient/__init__.py:135: error: Incompatible types in assignment (expression has type "None", variable has type "Gateway")  [assignment]
src/incomfortclient/__init__.py:137: error: Function is missing a return type annotation  [no-untyped-def]
src/incomfortclient/__init__.py:139: error: Cannot determine type of "_auth"  [has-type]
src/incomfortclient/__init__.py:143: error: Cannot determine type of "_url_base"  [has-type]
src/incomfortclient/__init__.py:144: error: Cannot determine type of "_auth"  [has-type]
src/incomfortclient/__init__.py:160: error: Incompatible default for argument "username" (default has type "None", argument has type "str")  [assignment]
src/incomfortclient/__init__.py:160: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/incomfortclient/__init__.py:160: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/incomfortclient/__init__.py:161: error: Incompatible default for argument "password" (default has type "None", argument has type "str")  [assignment]
src/incomfortclient/__init__.py:161: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/incomfortclient/__init__.py:161: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/incomfortclient/__init__.py:162: error: Incompatible default for argument "session" (default has type "None", argument has type "ClientSession")  [assignment]
src/incomfortclient/__init__.py:162: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/incomfortclient/__init__.py:162: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/incomfortclient/__init__.py:183: error: Cannot determine type of "_url_base"  [has-type]
src/incomfortclient/__init__.py:184: error: Cannot determine type of "_auth"  [has-type]
src/incomfortclient/__init__.py:187: error: Incompatible default for argument "force_refresh" (default has type "None", argument has type "bool")  [assignment]
src/incomfortclient/__init__.py:187: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/incomfortclient/__init__.py:187: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/incomfortclient/__init__.py:221: error: Missing type parameters for generic type "dict"  [type-arg]
src/incomfortclient/__init__.py:222: error: Missing type parameters for generic type "dict"  [type-arg]
src/incomfortclient/__init__.py:223: error: Incompatible types in assignment (expression has type "None", variable has type "list[Room]")  [assignment]
src/incomfortclient/__init__.py:240: error: Missing type parameters for generic type "dict"  [type-arg]
src/incomfortclient/__init__.py:247: error: Returning Any from function declared to return "int"  [no-any-return]
src/incomfortclient/__init__.py:254: error: Returning Any from function declared to return "Optional[str]"  [no-any-return]
src/incomfortclient/__init__.py:254: error: "list[Any]" has no attribute "get"  [attr-defined]
src/incomfortclient/__init__.py:280: error: Incompatible return value type (got "Optional[float]", expected "float")  [return-value]
src/incomfortclient/__init__.py:285: error: Incompatible return value type (got "Optional[float]", expected "float")  [return-value]
src/incomfortclient/__init__.py:290: error: Incompatible return value type (got "Optional[float]", expected "float")  [return-value]
src/incomfortclient/__init__.py:317: error: Missing type parameters for generic type "dict"  [type-arg]
src/incomfortclient/__init__.py:322: error: Missing type parameters for generic type "dict"  [type-arg]
inclient.py:46: error: Function is missing a return type annotation  [no-untyped-def]
inclient.py:85: error: Function is missing a type annotation  [no-untyped-def]
inclient.py:88: error: Call to untyped function "_parse_args" in typed context  [no-untyped-call]
inclient.py:136: error: Call to untyped function "main" in typed context  [no-untyped-call]
tests/common.py:23: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
tests/common.py:40: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
tests/test_heater.py:115: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_heater.py:115: note: Use "-> None" if function does not return a value
tests/test_heater.py:122: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_heater.py:122: note: Use "-> None" if function does not return a value
tests/test_gateway.py:33: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_gateway.py:33: note: Use "-> None" if function does not return a value
tests/test_gateway.py:43: error: Function is missing a type annotation  [no-untyped-def]
tests/test_gateway.py:53: error: Function is missing a type annotation  [no-untyped-def]
tests/test_gateway.py:56: error: Value of type "Optional[list[Heater]]" is not indexable  [index]
tests/test_gateway.py:57: error: Argument 1 to "len" has incompatible type "Optional[list[Heater]]"; expected "Sized"  [arg-type]
tests/test_gateway.py:57: error: Value of type "Optional[list[Heater]]" is not indexable  [index]
Found 46 errors in 5 files (checked 5 source files)
```