### PR TITLE
Fix display text is None if display_code or fault_code is 0

### DIFF
--- a/incomfortclient/__init__.py
+++ b/incomfortclient/__init__.py
@@ -290,8 +290,8 @@ class Heater(IncomfortObject):
     def display_text(self) -> str | None:
         """Return the display or fault code as text label rather than a code."""
         if self.is_failed:
-            return self.fault_code.name.lower() if self.fault_code else None
-        return self.display_code.name.lower() if self.display_code else None
+            return self.fault_code.name.lower() if self.fault_code is not None else None
+        return self.display_code.name.lower() if self.display_code is not None else None
 
     @property
     def is_burning(self) -> bool:


### PR DESCRIPTION
When the boilers display code or fault code is 0 the display_text would return None, this PR fixes that and returns the correct label now in these cases. 