### PR TITLE
Handle UnicodeDecodeError

### DIFF
--- a/incomfortclient/__init__.py
+++ b/incomfortclient/__init__.py
@@ -202,7 +202,7 @@ class Gateway(IncomfortObject):
 
         try:
             heaters = dict(await self._get("heaterlist.json"))[HEATERLIST]
-        except aiohttp.ClientError as exc:
+        except (aiohttp.ClientError, UnicodeDecodeError) as exc:
             raise InvalidGateway(exc) from exc
 
         self._heaters = [


### PR DESCRIPTION
In some cases calling the gateway without credentials can cause a UnicodeDecodeError.

See: https://github.com/home-assistant/core/issues/120898

This PR ensures a correct error handling when this error occurs.