### PR TITLE
Fix heater index formatting when setting an override temperature

### DIFF
--- a/incomfortclient/__init__.py
+++ b/incomfortclient/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import aiohttp
 
-__version__ = "0.6.3-1"
+__version__ = "0.6.4"
 
 NULL_SERIAL_NO = "000W00000"
 HEATERLIST = "heaterlist"
@@ -390,7 +390,9 @@ class Room(IncomfortObject):
                 f"{OVERRIDE_MIN_TEMP}-{OVERRIDE_MAX_TEMP}."
             ) from exc
 
-        url = "data.json?heater={self._heater._heater_idx}"
-        url += f"&thermostat={int(self.room_no) - 1}"
-        url += f"&setpoint={int((setpoint - OVERRIDE_MIN_TEMP) * 10)}"
+        url = (
+            f"data.json?heater={self._heater._heater_idx}"
+            f"&thermostat={int(self.room_no) - 1}"
+            f"&setpoint={int((setpoint - OVERRIDE_MIN_TEMP) * 10)}"
+        )
         await self._get(url)


### PR DESCRIPTION
## Overview
When a heater on the RF-gateway is not registered as the first heater device, and the index is not `0` but `1` or higher, setting an override temperature would fail because of a missing f-string marker.

This PR will fix the formatting to ensure the correct heater index is used.  