### PR TITLE
Improve add heater and room option for the CLI fix loop issue

### DIFF
--- a/tests/test_heater.py
+++ b/tests/test_heater.py
@@ -113,7 +113,6 @@ HEATER_WITH_ROOMS = (
 
 @pytest.mark.asyncio
 async def test_heater_sans_rooms():
-
     heater = await heater_with_status(HEATER_SANS_ROOMS[0])
     assert heater.status == HEATER_SANS_ROOMS[1]
     assert len(heater.rooms) == 0
@@ -121,7 +120,6 @@ async def test_heater_sans_rooms():
 
 @pytest.mark.asyncio
 async def test_heater_with_rooms():
-
     heater = await heater_with_status(HEATER_WITH_ROOMS[0])
     assert heater.status == HEATER_WITH_ROOMS[1]
     assert len(heater.rooms) == 1 and heater.rooms[0].status == HEATER_WITH_ROOMS[2]


### PR DESCRIPTION
Add the options to `inclient.py`
- -H --heater option (0-5)
- -R --room (0-2)

The default room has been changed to 0

The loop error has been fixed.

No changes to the client.

Bump lib version to 0.6.5