### PR TITLE
Move py.typed to the correct folder bump to v0.6.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "incomfort-client"
-version = "0.6.6"
+version = "0.6.7"
 description = "An aiohttp-based client for Intergas InComfort/InTouch Lan2RF systems."
 authors = ["Jan Bouwhuis <jan@jbsoft.nl>"]
 maintainers = ["Jan Bouwhuis <jan@jbsoft.nl>"]


### PR DESCRIPTION
FIx:
- move py.typed to the correct folder to ensure it is included in the package