### PR TITLE
Add display code 127 as status OFF - bump client to v0.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "incomfort-client"
-version = "0.6.7"
+version = "0.6.8"
 description = "An aiohttp-based client for Intergas InComfort/InTouch Lan2RF systems."
 authors = ["Jan Bouwhuis <jan@jbsoft.nl>"]
 maintainers = ["Jan Bouwhuis <jan@jbsoft.nl>"]

--- a/src/incomfortclient/__init__.py
+++ b/src/incomfortclient/__init__.py
@@ -44,6 +44,7 @@ class DisplayCode(IntEnum):
     SENSOR_TEST = 85
     CENTRAL_HEATING = 102
     STANDBY = 126
+    OFF = 127
     POSTRUN_BOYLER = 153
     SERVICE = 170
     TAPWATER = 204


### PR DESCRIPTION
## Proposed change

The display code 127 seems to be used to indicate the device is `OFF`.

The change fixes #48

The client version is bumped to v0.6.8