### PR TITLE
Add display code 104 mapping

### DIFF
--- a/src/incomfortclient/__init__.py
+++ b/src/incomfortclient/__init__.py
@@ -44,6 +44,7 @@ class DisplayCode(IntEnum):
     TAPWATER_INT = 51
     SENSOR_TEST = 85
     CENTRAL_HEATING = 102
+    CENTRAL_HEATING_LOW = 104
     STANDBY = 126
     OFF = 127
     POSTRUN_BOYLER = 153


### PR DESCRIPTION
Added display code 104 to a CH sub‑state.

Field logs show 104 only when burner+pump are on and DHW/fault are off, with lower CH flow temperatures than code 102. It appears to be a central‑heating low‑fire/modulating state, so mapped it to CENTRAL_HEATING_LOW to avoid “unknown”(making dirty HA logs).
